### PR TITLE
Remove demo tracker sample wav assets

### DIFF
--- a/assets/music/README.md
+++ b/assets/music/README.md
@@ -1,0 +1,15 @@
+# Demo-Tracker Sample Placeholders
+
+Add the following audio sample files (16-bit WAV recommended) to this folder so the Demo-Tracker can load them at runtime:
+
+- `lead-sample.wav` — Bright saw lead at middle C.
+- `bass-sample.wav` — Rounded triangle bass at middle C (C2 suggested).
+- `vocal-yeah.wav` — Short synthetic vocal "Yeah" hit.
+- `drum-kick.wav` — Punchy kick drum.
+- `drum-snare.wav` — Snare with noise snap.
+- `drum-hat.wav` — Tight closed hi-hat.
+- `drum-clap.wav` — Layered clap sample.
+- `drum-tom.wav` — Low floor tom.
+- `drum-cymbal.wav` — Long ride cymbal.
+
+Ensure each file name matches exactly so the tracker configuration in `config/config.json` can locate the samples.

--- a/config/config.json
+++ b/config/config.json
@@ -38,13 +38,183 @@
   },
   "audio": {
     "bpm": 120,
+    "swing": 0,
+    "stepsPerBar": 8,
     "loop": true,
-    "sampleBank": [],
-    "trackerPattern": [
-      { "note": "C4", "duration": 0.5 },
-      { "note": "E4", "duration": 0.5 },
-      { "note": "G4", "duration": 0.5 },
-      { "note": "C5", "duration": 0.5 }
+    "sampleLibrary": [
+      {
+        "id": "lead-main",
+        "name": "Lead Sample",
+        "description": "Bright saw lead sampled at middle C",
+        "category": "Lead",
+        "rootNote": "C4",
+        "file": "/assets/music/lead-sample.wav",
+        "color": "#ff6f91"
+      },
+      {
+        "id": "bass-main",
+        "name": "Bass Sample",
+        "description": "Rounded triangle bass",
+        "category": "Bass",
+        "rootNote": "C2",
+        "file": "/assets/music/bass-sample.wav",
+        "color": "#45c4b0"
+      },
+      {
+        "id": "vocal-yeah",
+        "name": "Vocal \"Yeah\"",
+        "description": "Short synthetic vocal hit",
+        "category": "Vocal",
+        "rootNote": "C4",
+        "file": "/assets/music/vocal-yeah.wav",
+        "color": "#ffd166"
+      },
+      {
+        "id": "drum-kick",
+        "name": "Drum Kick",
+        "description": "Punchy demo-scene kick",
+        "category": "Drums",
+        "rootNote": "C2",
+        "file": "/assets/music/drum-kick.wav",
+        "color": "#f25c54"
+      },
+      {
+        "id": "drum-snare",
+        "name": "Drum Snare",
+        "description": "Snare with noise snap",
+        "category": "Drums",
+        "rootNote": "C4",
+        "file": "/assets/music/drum-snare.wav",
+        "color": "#f9844a"
+      },
+      {
+        "id": "drum-hat",
+        "name": "Hi-Hat",
+        "description": "Tight closed hi-hat",
+        "category": "Drums",
+        "rootNote": "C5",
+        "file": "/assets/music/drum-hat.wav",
+        "color": "#6c63ff"
+      },
+      {
+        "id": "drum-clap",
+        "name": "Hand Clap",
+        "description": "Layered clap",
+        "category": "Drums",
+        "rootNote": "C4",
+        "file": "/assets/music/drum-clap.wav",
+        "color": "#ffad5a"
+      },
+      {
+        "id": "drum-tom",
+        "name": "Floor Tom",
+        "description": "Low tom hit",
+        "category": "Drums",
+        "rootNote": "C3",
+        "file": "/assets/music/drum-tom.wav",
+        "color": "#39a0ed"
+      },
+      {
+        "id": "drum-cymbal",
+        "name": "Ride Cymbal",
+        "description": "Long metallic cymbal",
+        "category": "Drums",
+        "rootNote": "C5",
+        "file": "/assets/music/drum-cymbal.wav",
+        "color": "#f7b801"
+      }
+    ],
+    "tracks": [
+      {
+        "id": "track-lead",
+        "name": "Lead",
+        "color": "#ff6f91",
+        "maxSampleSlots": 4,
+        "sampleSlots": [
+          { "id": "track-lead-slot-0", "sampleId": "lead-main" },
+          { "id": "track-lead-slot-1", "sampleId": null },
+          { "id": "track-lead-slot-2", "sampleId": null },
+          { "id": "track-lead-slot-3", "sampleId": null }
+        ],
+        "steps": [
+          { "enabled": true, "sampleSlot": 0, "pitch": 0, "volume": 0.85, "pan": -0.1, "reverse": false, "mod": "none" },
+          { "enabled": false, "sampleSlot": 0, "pitch": 0, "volume": 0.85, "pan": -0.1, "reverse": false, "mod": "none" },
+          { "enabled": true, "sampleSlot": 0, "pitch": 7, "volume": 0.82, "pan": 0.1, "reverse": false, "mod": "chorus" },
+          { "enabled": false, "sampleSlot": 0, "pitch": 0, "volume": 0.8, "pan": 0.15, "reverse": false, "mod": "none" },
+          { "enabled": true, "sampleSlot": 0, "pitch": 12, "volume": 0.9, "pan": -0.05, "reverse": false, "mod": "none" },
+          { "enabled": false, "sampleSlot": 0, "pitch": 0, "volume": 0.8, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": true, "sampleSlot": 0, "pitch": 7, "volume": 0.85, "pan": 0.15, "reverse": false, "mod": "delay" },
+          { "enabled": false, "sampleSlot": 0, "pitch": 0, "volume": 0.8, "pan": 0.05, "reverse": false, "mod": "none" }
+        ]
+      },
+      {
+        "id": "track-bass",
+        "name": "Bass",
+        "color": "#45c4b0",
+        "maxSampleSlots": 4,
+        "sampleSlots": [
+          { "id": "track-bass-slot-0", "sampleId": "bass-main" },
+          { "id": "track-bass-slot-1", "sampleId": null },
+          { "id": "track-bass-slot-2", "sampleId": null },
+          { "id": "track-bass-slot-3", "sampleId": null }
+        ],
+        "steps": [
+          { "enabled": true, "sampleSlot": 0, "pitch": -12, "volume": 0.9, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": false, "sampleSlot": 0, "pitch": 0, "volume": 0.9, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": true, "sampleSlot": 0, "pitch": -7, "volume": 0.95, "pan": 0, "reverse": false, "mod": "lpf" },
+          { "enabled": false, "sampleSlot": 0, "pitch": 0, "volume": 0.9, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": true, "sampleSlot": 0, "pitch": -12, "volume": 0.9, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": false, "sampleSlot": 0, "pitch": 0, "volume": 0.9, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": true, "sampleSlot": 0, "pitch": -5, "volume": 0.95, "pan": 0, "reverse": false, "mod": "lpf" },
+          { "enabled": false, "sampleSlot": 0, "pitch": 0, "volume": 0.9, "pan": 0, "reverse": false, "mod": "none" }
+        ]
+      },
+      {
+        "id": "track-vocal",
+        "name": "Vocal FX",
+        "color": "#ffd166",
+        "maxSampleSlots": 4,
+        "sampleSlots": [
+          { "id": "track-vocal-slot-0", "sampleId": "vocal-yeah" },
+          { "id": "track-vocal-slot-1", "sampleId": null },
+          { "id": "track-vocal-slot-2", "sampleId": null },
+          { "id": "track-vocal-slot-3", "sampleId": null }
+        ],
+        "steps": [
+          { "enabled": false, "sampleSlot": 0, "pitch": 0, "volume": 0.95, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": false, "sampleSlot": 0, "pitch": 0, "volume": 0.95, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": false, "sampleSlot": 0, "pitch": 0, "volume": 0.95, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": true, "sampleSlot": 0, "pitch": 0, "volume": 1, "pan": 0.25, "reverse": false, "mod": "chorus" },
+          { "enabled": false, "sampleSlot": 0, "pitch": 0, "volume": 0.95, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": false, "sampleSlot": 0, "pitch": 0, "volume": 0.95, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": false, "sampleSlot": 0, "pitch": 0, "volume": 0.95, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": true, "sampleSlot": 0, "pitch": 0, "volume": 0.85, "pan": -0.2, "reverse": true, "mod": "delay" }
+        ]
+      },
+      {
+        "id": "track-drums",
+        "name": "Drums",
+        "color": "#f25c54",
+        "maxSampleSlots": 6,
+        "sampleSlots": [
+          { "id": "track-drums-slot-0", "sampleId": "drum-kick" },
+          { "id": "track-drums-slot-1", "sampleId": "drum-snare" },
+          { "id": "track-drums-slot-2", "sampleId": "drum-hat" },
+          { "id": "track-drums-slot-3", "sampleId": "drum-clap" },
+          { "id": "track-drums-slot-4", "sampleId": "drum-tom" },
+          { "id": "track-drums-slot-5", "sampleId": "drum-cymbal" }
+        ],
+        "steps": [
+          { "enabled": true, "sampleSlot": 0, "pitch": 0, "volume": 1, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": true, "sampleSlot": 2, "pitch": 0, "volume": 0.7, "pan": -0.2, "reverse": false, "mod": "hpf" },
+          { "enabled": true, "sampleSlot": 0, "pitch": 0, "volume": 1, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": true, "sampleSlot": 3, "pitch": 0, "volume": 0.85, "pan": 0.1, "reverse": false, "mod": "bitcrush" },
+          { "enabled": true, "sampleSlot": 0, "pitch": 0, "volume": 1, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": true, "sampleSlot": 2, "pitch": 0, "volume": 0.75, "pan": 0.25, "reverse": false, "mod": "hpf" },
+          { "enabled": true, "sampleSlot": 0, "pitch": 0, "volume": 1, "pan": 0, "reverse": false, "mod": "none" },
+          { "enabled": true, "sampleSlot": 5, "pitch": 0, "volume": 0.8, "pan": 0.05, "reverse": false, "mod": "none" }
+        ]
+      }
     ]
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -26,8 +26,11 @@ async function loadConfig() {
       scroller: {},
       audio: {
         bpm: 120,
+        swing: 0,
+        stepsPerBar: 8,
         loop: true,
-        trackerPattern: []
+        sampleLibrary: [],
+        tracks: []
       }
     };
   }
@@ -68,6 +71,10 @@ class MegademoApp {
       },
       onAudioToggle: () => {
         this.toggleAudio();
+      },
+      onSamplePreview: (sampleId) => {
+        if (!sampleId) return;
+        this.audioEngine.previewSample(sampleId);
       }
     });
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -110,6 +110,16 @@ canvas {
   resize: vertical;
 }
 
+.control-panel .tracker-slot {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.control-panel .tracker-step-editor__row {
+  display: flex;
+  gap: 0.5rem;
+}
+
 button.playback-toggle {
   justify-self: flex-start;
   background: var(--accent);
@@ -125,6 +135,264 @@ button.playback-toggle {
 button.playback-toggle:hover {
   transform: translateY(-1px);
   box-shadow: 0 10px 20px rgba(72, 229, 194, 0.3);
+}
+
+.tracker {
+  margin-top: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.tracker__header h3 {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 1rem;
+  margin: 0;
+  color: var(--accent);
+  text-shadow: 0 0 10px rgba(72, 229, 194, 0.6);
+}
+
+.tracker__header p {
+  margin: 0.25rem 0 0;
+  color: rgba(248, 247, 255, 0.7);
+  font-size: 0.85rem;
+}
+
+.tracker__layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.tracker__library,
+.tracker__tracks {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.tracker__library h4 {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--accent-secondary);
+  font-family: 'Press Start 2P', monospace;
+}
+
+.tracker__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: rgba(248, 247, 255, 0.5);
+}
+
+.tracker__empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(248, 247, 255, 0.6);
+  background: rgba(72, 229, 194, 0.08);
+  border: 1px dashed rgba(72, 229, 194, 0.3);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+}
+
+.tracker-library__grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+}
+
+.tracker-sample {
+  border: 1px solid rgba(248, 247, 255, 0.1);
+  border-left: 4px solid var(--sample-color, var(--accent));
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: rgba(5, 3, 15, 0.6);
+  color: inherit;
+  display: grid;
+  gap: 0.35rem;
+  text-align: left;
+  cursor: pointer;
+  position: relative;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tracker-sample::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  pointer-events: none;
+}
+
+.tracker-sample:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 25px rgba(72, 229, 194, 0.15);
+}
+
+.tracker-sample__name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.tracker-sample__meta {
+  font-size: 0.75rem;
+  color: rgba(248, 247, 255, 0.6);
+}
+
+.tracker-sample__description {
+  font-size: 0.7rem;
+  color: rgba(248, 247, 255, 0.45);
+}
+
+.tracker-track {
+  border: 1px solid rgba(248, 247, 255, 0.08);
+  border-left: 4px solid var(--track-color, var(--accent-secondary));
+  border-radius: 12px;
+  padding: 1rem;
+  background: linear-gradient(135deg, rgba(5, 3, 15, 0.75), rgba(12, 8, 32, 0.85));
+  box-shadow: 0 0 30px rgba(0, 0, 0, 0.35);
+}
+
+.tracker-track__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tracker-track__header h5 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.tracker-track__slots {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.tracker-slot {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  color: rgba(248, 247, 255, 0.75);
+}
+
+.tracker-slot select {
+  border-radius: 6px;
+  padding: 0.35rem 0.5rem;
+  background: rgba(5, 3, 15, 0.75);
+  border: 1px solid rgba(248, 247, 255, 0.18);
+  color: inherit;
+}
+
+.tracker-track__grid {
+  display: grid;
+  gap: 0.4rem;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  margin-top: 1rem;
+}
+
+.tracker-step {
+  position: relative;
+  border-radius: 10px;
+  padding: 0.6rem 0.4rem 0.4rem;
+  border: 1px solid rgba(248, 247, 255, 0.12);
+  background: rgba(5, 3, 15, 0.65);
+  color: rgba(248, 247, 255, 0.75);
+  display: grid;
+  place-items: center;
+  gap: 0.25rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.2s ease;
+}
+
+.tracker-step--bar {
+  box-shadow: inset -4px 0 0 rgba(255, 255, 255, 0.05);
+}
+
+.tracker-step--active {
+  background: rgba(72, 229, 194, 0.12);
+  border-color: rgba(72, 229, 194, 0.6);
+  color: var(--text-primary);
+  box-shadow: 0 0 15px rgba(72, 229, 194, 0.2);
+}
+
+.tracker-step--selected {
+  transform: translateY(-3px);
+  box-shadow: 0 12px 20px rgba(132, 94, 247, 0.25);
+  border-color: rgba(132, 94, 247, 0.6);
+}
+
+.tracker-step__index {
+  font-size: 0.7rem;
+  opacity: 0.65;
+}
+
+.tracker-step__label {
+  font-size: 0.65rem;
+  text-align: center;
+}
+
+.tracker-step-editor {
+  margin-top: 1rem;
+  border-top: 1px solid rgba(248, 247, 255, 0.1);
+  padding-top: 1rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.tracker-step-editor__title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.tracker-step-editor__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: rgba(248, 247, 255, 0.85);
+}
+
+.tracker-step-editor__row input[type='checkbox'] {
+  transform: scale(1.1);
+}
+
+.tracker-step-editor__control {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tracker-step-editor__control input[type='range'] {
+  flex: 1;
+}
+
+.tracker-step-editor__value {
+  font-size: 0.75rem;
+  color: rgba(248, 247, 255, 0.65);
+  min-width: 64px;
+  text-align: right;
+}
+
+.tracker-step-editor select {
+  flex: 1;
+  padding: 0.3rem 0.5rem;
+  border-radius: 6px;
+  border: 1px solid rgba(248, 247, 255, 0.18);
+  background: rgba(5, 3, 15, 0.75);
+  color: inherit;
+}
+
+.tracker-step-editor--hidden {
+  display: none;
+}
+
+@media (min-width: 880px) {
+  .tracker__layout {
+    grid-template-columns: 1.1fr 1.6fr;
+  }
 }
 
 @media (min-width: 960px) {

--- a/src/ui/controls.js
+++ b/src/ui/controls.js
@@ -1,3 +1,5 @@
+import { createTrackerPanel } from './tracker.js';
+
 const clone = (value) =>
   typeof structuredClone === 'function' ? structuredClone(value) : JSON.parse(JSON.stringify(value));
 
@@ -68,7 +70,7 @@ function deepMerge(target, source) {
   return output;
 }
 
-export function createControlPanel(container, initialConfig, { onChange, onAudioToggle }) {
+export function createControlPanel(container, initialConfig, { onChange, onAudioToggle, onSamplePreview }) {
   let config = clone(initialConfig);
   container.innerHTML = '';
 
@@ -185,6 +187,19 @@ export function createControlPanel(container, initialConfig, { onChange, onAudio
   const audioGroup = createGroup('Audio');
   audioGroup.appendChild(playbackButton);
 
+  const trackerPanel = createTrackerPanel(config.audio ?? {}, {
+    onChange: (nextAudioConfig) => {
+      updateConfig({ audio: nextAudioConfig });
+    },
+    onSamplePreview: (sampleId) => {
+      if (typeof onSamplePreview === 'function') {
+        onSamplePreview(sampleId);
+      }
+    }
+  });
+
+  audioGroup.appendChild(trackerPanel.element);
+
   container.append(demoGroup, scrollerGroup, visualGroup, audioGroup);
 
   function updateConfig(partial) {
@@ -202,6 +217,7 @@ export function createControlPanel(container, initialConfig, { onChange, onAudio
     bobSpeedInput.value = String(config.visual?.bobs?.bobSpeed ?? 1.2);
     plasmaIntensityInput.value = String(config.visual?.plasma?.plasmaIntensity ?? 0.85);
     starSpeedInput.value = String(config.visual?.starfield?.starSpeed ?? 1.4);
+    trackerPanel.update(config.audio ?? {});
   }
 
   function setAudioState(isPlaying) {

--- a/src/ui/tracker.js
+++ b/src/ui/tracker.js
@@ -1,0 +1,557 @@
+import { normalizeAudioConfig } from '../audio/index.js';
+
+const clone = (value) =>
+  typeof structuredClone === 'function' ? structuredClone(value) : JSON.parse(JSON.stringify(value));
+
+const MOD_OPTIONS = [
+  { value: 'none', label: 'None (dry signal)' },
+  { value: 'lpf', label: 'Low-pass smooth' },
+  { value: 'hpf', label: 'High-pass snap' },
+  { value: 'bitcrush', label: 'Bitcrush grit' },
+  { value: 'chorus', label: 'Chorus doubler' },
+  { value: 'delay', label: 'Echo delay' }
+];
+
+function formatPitch(value) {
+  const numeric = Number.parseInt(value, 10) || 0;
+  if (numeric === 0) return '0 st';
+  return `${numeric > 0 ? '+' : ''}${numeric} st`;
+}
+
+function formatVolume(value) {
+  const numeric = Number.parseFloat(value);
+  return `${Math.round(clamp(numeric, 0, 2) * 100)}%`;
+}
+
+function formatPan(value) {
+  const numeric = Number.parseFloat(value) || 0;
+  if (Math.abs(numeric) < 0.01) return 'Center';
+  return numeric < 0 ? `Left ${Math.round(Math.abs(numeric) * 100)}%` : `Right ${Math.round(numeric * 100)}%`;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function createOption(value, label) {
+  const option = document.createElement('option');
+  option.value = value;
+  option.textContent = label;
+  return option;
+}
+
+function getSampleById(audioConfig, sampleId) {
+  if (!sampleId) return null;
+  return audioConfig.sampleLibrary.find((sample) => sample.id === sampleId) ?? null;
+}
+
+function getSampleSlotLabel(audioConfig, track, slotIndex) {
+  const slot = track.sampleSlots?.[slotIndex];
+  if (!slot) return `Slot ${slotIndex + 1}`;
+  const sample = getSampleById(audioConfig, slot.sampleId);
+  if (!sample) return `Slot ${slotIndex + 1}: Empty`;
+  return `Slot ${slotIndex + 1}: ${sample.name}`;
+}
+
+function createLibraryCard(sample, onPreview) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'tracker-sample';
+  button.style.setProperty('--sample-color', sample.color ?? '#48e5c2');
+
+  const name = document.createElement('span');
+  name.className = 'tracker-sample__name';
+  name.textContent = sample.name;
+
+  const meta = document.createElement('span');
+  meta.className = 'tracker-sample__meta';
+  meta.textContent = sample.category ?? '';
+
+  const description = document.createElement('span');
+  description.className = 'tracker-sample__description';
+  description.textContent = sample.description ?? '';
+
+  button.append(name, meta, description);
+
+  button.addEventListener('click', () => {
+    if (typeof onPreview === 'function') {
+      onPreview(sample.id);
+    }
+  });
+
+  return button;
+}
+
+function createStepButton(stepIndex) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'tracker-step';
+  if ((stepIndex + 1) % 4 === 0) {
+    button.classList.add('tracker-step--bar');
+  }
+
+  const indexLabel = document.createElement('span');
+  indexLabel.className = 'tracker-step__index';
+  indexLabel.textContent = String(stepIndex + 1);
+
+  const sampleLabel = document.createElement('span');
+  sampleLabel.className = 'tracker-step__label';
+  sampleLabel.textContent = '';
+
+  button.append(indexLabel, sampleLabel);
+  return { button, sampleLabel };
+}
+
+export function createTrackerPanel(initialAudioConfig = {}, { onChange, onSamplePreview } = {}) {
+  let audioConfig = normalizeAudioConfig(initialAudioConfig);
+  let selected = { trackIndex: 0, stepIndex: 0 };
+
+  const root = document.createElement('div');
+  root.className = 'tracker';
+
+  const header = document.createElement('header');
+  header.className = 'tracker__header';
+  const title = document.createElement('h3');
+  title.textContent = 'Demo-Tracker';
+  const subtitle = document.createElement('p');
+  subtitle.textContent = '4-track sample sequencer with an 8-step grid.';
+  header.append(title, subtitle);
+  root.appendChild(header);
+
+  const layout = document.createElement('div');
+  layout.className = 'tracker__layout';
+  root.appendChild(layout);
+
+  const librarySection = document.createElement('section');
+  librarySection.className = 'tracker__library';
+  const libraryHeading = document.createElement('h4');
+  libraryHeading.textContent = 'Sample Library';
+  const libraryHint = document.createElement('p');
+  libraryHint.className = 'tracker__hint';
+  libraryHint.textContent = 'Click a card to preview and then assign it to a track slot.';
+  const libraryGrid = document.createElement('div');
+  libraryGrid.className = 'tracker-library__grid';
+  librarySection.append(libraryHeading, libraryHint, libraryGrid);
+  layout.appendChild(librarySection);
+
+  const tracksSection = document.createElement('section');
+  tracksSection.className = 'tracker__tracks';
+  layout.appendChild(tracksSection);
+
+  const trackViews = [];
+
+  function emitChange() {
+    if (typeof onChange === 'function') {
+      onChange(clone(audioConfig));
+    }
+  }
+
+  function ensureSelectionBounds() {
+    if (!audioConfig.tracks.length) {
+      selected = { trackIndex: 0, stepIndex: 0 };
+      return;
+    }
+    selected.trackIndex = clamp(selected.trackIndex, 0, audioConfig.tracks.length - 1);
+    const currentTrack = audioConfig.tracks[selected.trackIndex];
+    if (!currentTrack || currentTrack.steps.length === 0) {
+      selected.stepIndex = 0;
+      return;
+    }
+    selected.stepIndex = clamp(selected.stepIndex, 0, currentTrack.steps.length - 1);
+  }
+
+  function getSelectedStep() {
+    const track = audioConfig.tracks[selected.trackIndex];
+    if (!track) return null;
+    return track.steps[selected.stepIndex] ?? null;
+  }
+
+  function getSelectedTrack() {
+    return audioConfig.tracks[selected.trackIndex] ?? null;
+  }
+
+  function updateLibrary() {
+    libraryGrid.innerHTML = '';
+    if (audioConfig.sampleLibrary.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'tracker__empty';
+      empty.textContent = 'No samples loaded yet. Add them to config/config.json to expand your palette!';
+      libraryGrid.appendChild(empty);
+      return;
+    }
+    audioConfig.sampleLibrary.forEach((sample) => {
+      libraryGrid.appendChild(createLibraryCard(sample, onSamplePreview));
+    });
+  }
+
+  function buildTrackView(track, trackIndex) {
+    const section = document.createElement('article');
+    section.className = 'tracker-track';
+    section.style.setProperty('--track-color', track.color ?? '#48e5c2');
+
+    const headerRow = document.createElement('header');
+    headerRow.className = 'tracker-track__header';
+    const heading = document.createElement('h5');
+    heading.textContent = track.name ?? `Track ${trackIndex + 1}`;
+    headerRow.appendChild(heading);
+
+    const slotsWrapper = document.createElement('div');
+    slotsWrapper.className = 'tracker-track__slots';
+    const slotSelects = [];
+    track.sampleSlots.forEach((slot, slotIndex) => {
+      const slotLabel = document.createElement('label');
+      slotLabel.className = 'tracker-slot';
+      const name = document.createElement('span');
+      name.className = 'tracker-slot__name';
+      name.textContent = `Slot ${slotIndex + 1}`;
+      const select = document.createElement('select');
+      const emptyOption = createOption('', 'Empty');
+      select.appendChild(emptyOption);
+      audioConfig.sampleLibrary.forEach((sample) => {
+        select.appendChild(createOption(sample.id, sample.name));
+      });
+      select.value = slot.sampleId ?? '';
+      select.addEventListener('change', () => {
+        const nextValue = select.value || null;
+        audioConfig.tracks[trackIndex].sampleSlots[slotIndex].sampleId = nextValue;
+        emitChange();
+        syncTrack(trackIndex);
+        if (selected.trackIndex === trackIndex) {
+          syncEditor();
+        }
+      });
+      slotLabel.append(name, select);
+      slotsWrapper.appendChild(slotLabel);
+      slotSelects.push(select);
+    });
+    headerRow.appendChild(slotsWrapper);
+    section.appendChild(headerRow);
+
+    const grid = document.createElement('div');
+    grid.className = 'tracker-track__grid';
+    const stepButtons = [];
+    const stepLabels = [];
+    track.steps.forEach((_, stepIndex) => {
+      const { button, sampleLabel } = createStepButton(stepIndex);
+      button.addEventListener('click', () => {
+        selected = { trackIndex, stepIndex };
+        const step = audioConfig.tracks[trackIndex].steps[stepIndex];
+        if (!step.enabled) {
+          const defaultSlot = audioConfig.tracks[trackIndex].sampleSlots.findIndex((slot) => slot.sampleId);
+          if (defaultSlot >= 0) {
+            step.sampleSlot = defaultSlot;
+          }
+          step.enabled = true;
+          emitChange();
+        }
+        syncTrack(trackIndex);
+        syncEditor();
+      });
+      grid.appendChild(button);
+      stepButtons.push(button);
+      stepLabels.push(sampleLabel);
+    });
+    section.appendChild(grid);
+
+    const editor = createStepEditor(trackIndex);
+    section.appendChild(editor.root);
+
+    return { section, slotSelects, stepButtons, stepLabels, editor };
+  }
+
+  function buildTracks() {
+    tracksSection.innerHTML = '';
+    trackViews.length = 0;
+    audioConfig.tracks.forEach((track, index) => {
+      const view = buildTrackView(track, index);
+      trackViews[index] = view;
+      tracksSection.appendChild(view.section);
+    });
+  }
+
+  function syncSlotOptions(trackIndex) {
+    const view = trackViews[trackIndex];
+    if (!view) return;
+    const track = audioConfig.tracks[trackIndex];
+    view.slotSelects.forEach((select, slotIndex) => {
+      select.innerHTML = '';
+      select.appendChild(createOption('', 'Empty'));
+      audioConfig.sampleLibrary.forEach((sample) => {
+        select.appendChild(createOption(sample.id, sample.name));
+      });
+      select.value = track.sampleSlots[slotIndex]?.sampleId ?? '';
+    });
+  }
+
+  function syncTrack(trackIndex) {
+    const view = trackViews[trackIndex];
+    const track = audioConfig.tracks[trackIndex];
+    if (!view || !track) return;
+
+    syncSlotOptions(trackIndex);
+
+    track.steps.forEach((step, stepIndex) => {
+      const button = view.stepButtons[stepIndex];
+      const label = view.stepLabels[stepIndex];
+      if (!button || !label) return;
+      button.classList.toggle('tracker-step--active', Boolean(step.enabled));
+      button.classList.toggle('tracker-step--selected',
+        selected.trackIndex === trackIndex && selected.stepIndex === stepIndex
+      );
+      const slotLabel = getSampleSlotLabel(audioConfig, track, step.sampleSlot ?? 0);
+      label.textContent = step.enabled ? slotLabel.replace(/^Slot \d+:\s*/, '') : '—';
+      button.title = `${track.name ?? 'Track'} • Step ${stepIndex + 1}${step.enabled ? ` • ${slotLabel}` : ''}`;
+    });
+  }
+
+  function syncTracks() {
+    audioConfig.tracks.forEach((_, index) => syncTrack(index));
+  }
+
+  function createStepEditor(trackIndex) {
+    const root = document.createElement('div');
+    root.className = 'tracker-step-editor';
+
+    const title = document.createElement('div');
+    title.className = 'tracker-step-editor__title';
+    root.appendChild(title);
+
+    const enableLabel = document.createElement('label');
+    enableLabel.className = 'tracker-step-editor__row';
+    const enableText = document.createElement('span');
+    enableText.textContent = 'Enable step';
+    const enableToggle = document.createElement('input');
+    enableToggle.type = 'checkbox';
+    enableLabel.append(enableText, enableToggle);
+
+    const sampleLabel = document.createElement('label');
+    sampleLabel.className = 'tracker-step-editor__row';
+    const sampleText = document.createElement('span');
+    sampleText.textContent = 'Sample slot';
+    const sampleSelect = document.createElement('select');
+    sampleLabel.append(sampleText, sampleSelect);
+
+    const pitchLabel = document.createElement('label');
+    pitchLabel.className = 'tracker-step-editor__row';
+    const pitchText = document.createElement('span');
+    pitchText.textContent = 'Pitch';
+    const pitchValue = document.createElement('span');
+    pitchValue.className = 'tracker-step-editor__value';
+    const pitchInput = document.createElement('input');
+    pitchInput.type = 'range';
+    pitchInput.min = '-24';
+    pitchInput.max = '24';
+    pitchInput.step = '1';
+    const pitchWrapper = document.createElement('div');
+    pitchWrapper.className = 'tracker-step-editor__control';
+    pitchWrapper.append(pitchInput, pitchValue);
+    pitchLabel.append(pitchText, pitchWrapper);
+
+    const volumeLabel = document.createElement('label');
+    volumeLabel.className = 'tracker-step-editor__row';
+    const volumeText = document.createElement('span');
+    volumeText.textContent = 'Volume';
+    const volumeValue = document.createElement('span');
+    volumeValue.className = 'tracker-step-editor__value';
+    const volumeInput = document.createElement('input');
+    volumeInput.type = 'range';
+    volumeInput.min = '0';
+    volumeInput.max = '1.5';
+    volumeInput.step = '0.01';
+    const volumeWrapper = document.createElement('div');
+    volumeWrapper.className = 'tracker-step-editor__control';
+    volumeWrapper.append(volumeInput, volumeValue);
+    volumeLabel.append(volumeText, volumeWrapper);
+
+    const panLabel = document.createElement('label');
+    panLabel.className = 'tracker-step-editor__row';
+    const panText = document.createElement('span');
+    panText.textContent = 'Pan';
+    const panValue = document.createElement('span');
+    panValue.className = 'tracker-step-editor__value';
+    const panInput = document.createElement('input');
+    panInput.type = 'range';
+    panInput.min = '-1';
+    panInput.max = '1';
+    panInput.step = '0.05';
+    const panWrapper = document.createElement('div');
+    panWrapper.className = 'tracker-step-editor__control';
+    panWrapper.append(panInput, panValue);
+    panLabel.append(panText, panWrapper);
+
+    const reverseLabel = document.createElement('label');
+    reverseLabel.className = 'tracker-step-editor__row';
+    const reverseText = document.createElement('span');
+    reverseText.textContent = 'Reverse';
+    const reverseToggle = document.createElement('input');
+    reverseToggle.type = 'checkbox';
+    reverseLabel.append(reverseText, reverseToggle);
+
+    const modLabel = document.createElement('label');
+    modLabel.className = 'tracker-step-editor__row';
+    const modText = document.createElement('span');
+    modText.textContent = 'Mod FX';
+    const modSelect = document.createElement('select');
+    MOD_OPTIONS.forEach((option) => {
+      modSelect.appendChild(createOption(option.value, option.label));
+    });
+    modLabel.append(modText, modSelect);
+
+    root.append(
+      enableLabel,
+      sampleLabel,
+      pitchLabel,
+      volumeLabel,
+      panLabel,
+      reverseLabel,
+      modLabel
+    );
+
+    enableToggle.addEventListener('change', () => {
+      const step = getSelectedStep();
+      if (!step) return;
+      step.enabled = enableToggle.checked;
+      emitChange();
+      syncTrack(trackIndex);
+      syncEditor();
+    });
+
+    sampleSelect.addEventListener('change', () => {
+      const step = getSelectedStep();
+      if (!step) return;
+      step.sampleSlot = Number.parseInt(sampleSelect.value, 10) || 0;
+      emitChange();
+      syncTrack(trackIndex);
+      syncEditor();
+    });
+
+    pitchInput.addEventListener('input', () => {
+      pitchValue.textContent = formatPitch(pitchInput.value);
+    });
+    pitchInput.addEventListener('change', () => {
+      const step = getSelectedStep();
+      if (!step) return;
+      step.pitch = Number.parseInt(pitchInput.value, 10) || 0;
+      emitChange();
+    });
+
+    volumeInput.addEventListener('input', () => {
+      volumeValue.textContent = formatVolume(volumeInput.value);
+    });
+    volumeInput.addEventListener('change', () => {
+      const step = getSelectedStep();
+      if (!step) return;
+      step.volume = Number.parseFloat(volumeInput.value) || 0;
+      emitChange();
+    });
+
+    panInput.addEventListener('input', () => {
+      panValue.textContent = formatPan(panInput.value);
+    });
+    panInput.addEventListener('change', () => {
+      const step = getSelectedStep();
+      if (!step) return;
+      step.pan = Number.parseFloat(panInput.value) || 0;
+      emitChange();
+      syncTrack(trackIndex);
+    });
+
+    reverseToggle.addEventListener('change', () => {
+      const step = getSelectedStep();
+      if (!step) return;
+      step.reverse = reverseToggle.checked;
+      emitChange();
+    });
+
+    modSelect.addEventListener('change', () => {
+      const step = getSelectedStep();
+      if (!step) return;
+      step.mod = modSelect.value;
+      emitChange();
+    });
+
+    return {
+      root,
+      title,
+      enableToggle,
+      sampleSelect,
+      pitchInput,
+      pitchValue,
+      volumeInput,
+      volumeValue,
+      panInput,
+      panValue,
+      reverseToggle,
+      modSelect
+    };
+  }
+
+  function syncEditor() {
+    ensureSelectionBounds();
+    const track = getSelectedTrack();
+    if (!track) return;
+    const view = trackViews[selected.trackIndex];
+    if (!view) return;
+    const step = getSelectedStep();
+    if (!step) {
+      view.editor.root.classList.add('tracker-step-editor--hidden');
+      return;
+    }
+
+    view.editor.root.classList.remove('tracker-step-editor--hidden');
+    view.editor.title.textContent = `${track.name ?? 'Track'} • Step ${selected.stepIndex + 1}`;
+
+    view.editor.enableToggle.checked = Boolean(step.enabled);
+
+    view.editor.sampleSelect.innerHTML = '';
+    track.sampleSlots.forEach((_, slotIndex) => {
+      view.editor.sampleSelect.appendChild(createOption(String(slotIndex), getSampleSlotLabel(audioConfig, track, slotIndex)));
+    });
+    view.editor.sampleSelect.value = String(step.sampleSlot ?? 0);
+
+    view.editor.pitchInput.value = String(step.pitch ?? 0);
+    view.editor.pitchValue.textContent = formatPitch(step.pitch ?? 0);
+
+    view.editor.volumeInput.value = String(step.volume ?? 1);
+    view.editor.volumeValue.textContent = formatVolume(step.volume ?? 1);
+
+    view.editor.panInput.value = String(step.pan ?? 0);
+    view.editor.panValue.textContent = formatPan(step.pan ?? 0);
+
+    view.editor.reverseToggle.checked = Boolean(step.reverse);
+    view.editor.modSelect.value = step.mod ?? 'none';
+
+    const disabled = !step.enabled;
+    [
+      view.editor.sampleSelect,
+      view.editor.pitchInput,
+      view.editor.volumeInput,
+      view.editor.panInput,
+      view.editor.reverseToggle,
+      view.editor.modSelect
+    ].forEach((control) => {
+      control.disabled = disabled;
+    });
+  }
+
+  function syncAll() {
+    ensureSelectionBounds();
+    updateLibrary();
+    buildTracks();
+    syncTracks();
+    syncEditor();
+  }
+
+  syncAll();
+
+  function update(nextAudioConfig) {
+    audioConfig = normalizeAudioConfig(nextAudioConfig ?? {});
+    ensureSelectionBounds();
+    syncAll();
+  }
+
+  return {
+    element: root,
+    update
+  };
+}


### PR DESCRIPTION
## Summary
- replace the audio engine with a sample-based Demo-Tracker that supports per-step pitch, pan, modulation, and sample preview
- add a dedicated tracker editor UI with sample library cards, slot assignment, and an 8-step grid for the four tracks
- document the required Demo-Tracker sample filenames, remove the committed WAV assets, and make sample loading resilient when files are missing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2adbc9ffc833095e3bf500371f0d0