### PR TITLE
🧹 Remove unimplemented 'Export' stub

### DIFF
--- a/src/ui/controls.js
+++ b/src/ui/controls.js
@@ -113,7 +113,7 @@ export function createControlPanel(container, initialConfig, { onChange, onPlayb
   nav.style.gap = '10px';
   nav.style.marginBottom = '20px';
 
-  const steps = ['1. Setup', '2. Sound Tracker', '3. Configure Parts', '4. Playback', '5. Export'];
+  const steps = ['1. Setup', '2. Sound Tracker', '3. Configure Parts', '4. Playback'];
   const navButtons = steps.map((text, idx) => {
     const btn = document.createElement('button');
     btn.textContent = text;
@@ -403,15 +403,6 @@ export function createControlPanel(container, initialConfig, { onChange, onPlayb
     content.appendChild(group.element);
   }
 
-  // --- STEP 5: EXPORT ---
-  function renderExport() {
-    const group = createGroup('Export Options');
-    const p = document.createElement('p');
-    p.textContent = 'Export functionality (e.g., video recording, social sharing) will be implemented here.';
-    group.content.appendChild(p);
-    content.appendChild(group.element);
-  }
-
   function render() {
     navButtons.forEach((btn, idx) => {
       if (currentStep === idx + 1) {
@@ -430,7 +421,6 @@ export function createControlPanel(container, initialConfig, { onChange, onPlayb
     else if (currentStep === 2) renderSoundTracker();
     else if (currentStep === 3) renderConfigureParts();
     else if (currentStep === 4) renderPlayback();
-    else if (currentStep === 5) renderExport();
   }
 
   syncPartsArray();


### PR DESCRIPTION
🎯 **What:** Removed the unimplemented 'renderExport' stub and all its references from the `src/ui/controls.js` file.
💡 **Why:** This cleanup reduces technical debt by removing dead code and an unnecessary UI step for a feature that is not currently implemented. It makes the codebase more maintainable and its current state more accurately reflect the available features.
✅ **Verification:** Manually verified the changes in `src/ui/controls.js` to ensure the logic and indices remain consistent. Confirmed the file remains syntactically valid and that the 'Export' step is no longer referenced.
✨ **Result:** A cleaner, more focused UI and code structure, with no leftover stubs for unimplemented features.

---
*PR created automatically by Jules for task [16014337365633619510](https://jules.google.com/task/16014337365633619510) started by @mystervee*