### PR TITLE
🧹 Extract shared utility functions into src/utils.js

### DIFF
--- a/src/audio/index.js
+++ b/src/audio/index.js
@@ -1,9 +1,8 @@
+import { clone, clamp, ensureArray } from "../utils.js";
 const DEFAULT_STEP_COUNT = 8;
 const DEFAULT_TIME_DIVISION = 2;
 const MAX_SWING = 0.45;
 
-const clone = (value) =>
-  typeof structuredClone === 'function' ? structuredClone(value) : JSON.parse(JSON.stringify(value));
 
 const DEFAULT_AUDIO_CONFIG = {
   bpm: 120,
@@ -15,13 +14,6 @@ const DEFAULT_AUDIO_CONFIG = {
   tracks: []
 };
 
-function clamp(value, min, max) {
-  return Math.min(Math.max(value, min), max);
-}
-
-function ensureArray(value) {
-  return Array.isArray(value) ? value : [];
-}
 
 function normaliseSample(sample = {}, index = 0) {
   return {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,10 @@
+export const clone = (value) =>
+  typeof structuredClone === 'function' ? structuredClone(value) : JSON.parse(JSON.stringify(value));
+
+export function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function ensureArray(value) {
+  return Array.isArray(value) ? value : [];
+}


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted duplicated `clone`, `clamp`, and `ensureArray` utility functions from `src/audio/index.js` into a new, shared `src/utils.js` file using named exports.

💡 **Why:** How this improves maintainability
This reduces duplication, centralizes general utility functions to a single file, and sets up a standard location for future shared functions, making the codebase cleaner and easier to maintain.

✅ **Verification:** How you confirmed the change is safe
- Extracted and imported functions properly.
- Kept the same signature and logic as before.
- Ran tests via `npx vitest run` to ensure nothing was broken.

✨ **Result:** The improvement achieved
A centralized utility file `src/utils.js` has been created, and `src/audio/index.js` has been simplified by moving standalone helper methods out of the main module logic.

---
*PR created automatically by Jules for task [10086409474026642223](https://jules.google.com/task/10086409474026642223) started by @mystervee*