### PR TITLE
Update Layout and Scrolling for the Sound Tracker Tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -140,7 +139,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1601,7 +1599,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",

--- a/src/ui/controls.js
+++ b/src/ui/controls.js
@@ -213,7 +213,7 @@ export function createControlPanel(container, initialConfig, { onChange, onPlayb
   // --- STEP 2: SOUND TRACKER ---
   function renderSoundTracker() {
     const group = createGroup('Global Tune Settings');
-    group.content.style.height = '400px';
+    group.content.style.height = '520px';
     
     trackerPanelInstance.update(config);
     group.content.appendChild(trackerPanelInstance.element);

--- a/src/ui/tracker.js
+++ b/src/ui/tracker.js
@@ -48,6 +48,7 @@ export function createTrackerPanel(initialConfig = {}, { onChange, onSamplePrevi
   root.style.flexDirection = 'row';
   root.style.gap = '20px';
   root.style.height = '100%';
+  root.style.minWidth = '0';
 
   const libraryContainer = document.createElement('div');
   libraryContainer.className = 'tracker-library';
@@ -101,7 +102,7 @@ export function createTrackerPanel(initialConfig = {}, { onChange, onSamplePrevi
   gridContainerWrapper.style.width = '100%';
   gridContainerWrapper.style.maxWidth = '100%';
   gridContainerWrapper.style.minWidth = '0';
-  gridContainerWrapper.style.flex = '1';
+  gridContainerWrapper.style.flex = '1 1 0%';
 
   const headersContainer = document.createElement('div');
   headersContainer.className = 'tracker-headers';
@@ -157,7 +158,7 @@ export function createTrackerPanel(initialConfig = {}, { onChange, onSamplePrevi
 
     trackerState.trackEffects.forEach((fx, trackIndex) => {
       const header = document.createElement('div');
-      header.style.height = '80px';
+      header.style.height = '100px';
       header.style.border = '1px solid #ccc';
       header.style.marginBottom = '4px';
       header.style.padding = '5px';
@@ -203,7 +204,7 @@ export function createTrackerPanel(initialConfig = {}, { onChange, onSamplePrevi
   gridScrollable.style.overflowY = 'hidden';
   gridScrollable.style.paddingBottom = '10px';
   gridScrollable.style.minWidth = '0';
-  gridScrollable.style.flex = '1 1 auto';
+  gridScrollable.style.flex = '1 1 0%';
 
   function renderGrid() {
     gridScrollable.innerHTML = '';
@@ -237,7 +238,7 @@ export function createTrackerPanel(initialConfig = {}, { onChange, onSamplePrevi
       row.style.display = 'flex';
       row.style.flexWrap = 'nowrap';
       row.style.width = 'max-content';
-      row.style.height = '80px';
+      row.style.height = '100px';
       row.style.marginBottom = '4px';
 
       for (let stepIndex = 0; stepIndex < 64; stepIndex++) {


### PR DESCRIPTION
Addresses the layout issues on the Sound Tracker tab.
- Increases the track height by 20px (rows and sticky headers) to improve usability.
- Isolates horizontal scrolling to the steps timeline by applying correct flexbox constraints (`min-width: 0` and `flex-basis: 0%` via `flex: 1 1 0%`) to the grid container and its wrappers, preventing the 64-step grid from forcing a page-level horizontal scrollbar.

---
*PR created automatically by Jules for task [15747339801906374940](https://jules.google.com/task/15747339801906374940) started by @mystervee*