### PR TITLE
🔒 Fix Prototype Pollution in deepMerge

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -79,6 +79,7 @@ function getAudioEngineConfig(config = {}) {
 function deepMerge(target, source) {
   const output = clone(target);
   Object.entries(source).forEach(([key, value]) => {
+    if (key === '__proto__' || key === 'constructor') return;
     if (value && typeof value === 'object' && !Array.isArray(value)) {
       output[key] = deepMerge(output[key] ?? {}, value);
     } else {

--- a/src/ui/controls.js
+++ b/src/ui/controls.js
@@ -71,6 +71,7 @@ function createSelect({ label, options, value }) {
 function deepMerge(target, source) {
   const output = clone(target);
   Object.entries(source).forEach(([key, value]) => {
+    if (key === '__proto__' || key === 'constructor') return;
     if (value && typeof value === 'object' && !Array.isArray(value)) {
       output[key] = deepMerge(output[key] ?? {}, value);
     } else {


### PR DESCRIPTION
🎯 **What:** Fixed a Prototype Pollution vulnerability in the `deepMerge` function.
⚠️ **Risk:** An attacker could supply a malicious object containing `__proto__` or `constructor` keys to the `deepMerge` function, which would recursively merge them, potentially mutating `Object.prototype`. This could alter application behavior globally, leading to privilege escalation, Denial of Service (DoS), or arbitrary code execution depending on where these polluted properties are accessed.
🛡️ **Solution:** Added a guard block within the `Object.entries(source).forEach` loop of the `deepMerge` function in both `src/ui/controls.js` and `src/main.js`. If the key is `__proto__` or `constructor`, the loop skips to the next key, effectively sanitizing the input and neutralizing the attack vector.

---
*PR created automatically by Jules for task [13986344348919428695](https://jules.google.com/task/13986344348919428695) started by @mystervee*